### PR TITLE
SDDM: Maliit keyboard

### DIFF
--- a/recipes-support/sddm/sddm/sddm.conf
+++ b/recipes-support/sddm/sddm/sddm.conf
@@ -21,7 +21,7 @@ GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
 HaltCommand=/usr/bin/systemctl poweroff
 
 # Input method module
-#InputMethod=qtvirtualkeyboard
+InputMethod=
 
 # Comma-separated list of Linux namespaces for user session to enter
 Namespaces=
@@ -93,7 +93,7 @@ ReuseSession=true
 
 [Wayland]
 # Path of the Wayland compositor to execute when starting the greeter
-CompositorCommand=kwin_wayland --no-lockscreen
+CompositorCommand=kwin_wayland --no-lockscreen --no-global-shortcuts --inputmethod maliit-keyboard
 #CompositorCommand=weston --shell=fullscreen-shell.so --backend=drm-backend.so --drm-device=card1
 
 # Enable Qt's automatic high-DPI scaling


### PR DESCRIPTION
Fixes maliit keyboard on sddm, currently it pops up for a brief second and then closes, this fixes it so you can unlock the tablet without the keyboard attached. 

Also adds in no global shortcuts as recommended by archlinux wiki to prevent bypassing sdm via key bindings