### PR TITLE
Fix error where bad commit ID breaks the build script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,11 +50,15 @@ do
 	if [ ! -d layers/$layer/.git ]
 	then
 		echo "Cloning $layer"
-		git clone -q $repo layers/$layer && cd layers/$layer && git checkout -q $branch  && git checkout -q $srcrev && cd ../..
+		git clone -q $repo layers/$layer && cd layers/$layer
+                git checkout -q $branch  && git checkout -q $srcrev
+                cd ../..
 	else
 		if [ $NOSYNC -eq 0 ]; then
 			echo "Updating $layer to $srcrev"
-			cd layers/$layer && git fetch -q && git checkout -q $branch && git checkout -q $srcrev && cd ../..
+			cd layers/$layer
+                        git fetch -q && git checkout -q $branch && git checkout -q $srcrev
+                        cd ../..
 		fi
 	fi
 done


### PR DESCRIPTION
Currently if the setup script has an invalid commit hash for a sub-dependency, then it breaks in a way where files get checked out in the incorrect directories. In my case a bad commit for `yocto-meta-kf5` causes an error which then causes all of the following repositories to be checked out int `layers/yocto-meta-kf5/layers` instead of the correct directory.